### PR TITLE
Refactor: Migrate cart state to Context API

### DIFF
--- a/fakecart/src/App.tsx
+++ b/fakecart/src/App.tsx
@@ -11,9 +11,10 @@ import { useState } from 'react'
 // import smartwatch from './assets/images/smartwatch.jpg';
 // import mouse from './assets/images/mouse.jpg';
 // -------------------------------------------------------
-import type { Product } from './types/Product'
+// import type { Product } from './types/Product'
 import Home from './pages/Home'
-import { updateCartItems } from './utils/cartUtils'
+import { CartProvider } from './context/CartContext'
+// import { updateCartItems } from './utils/cartUtils'
 
 
 
@@ -31,26 +32,21 @@ const App: React.FC = () => {
   // }]);
   // --------------------------------------------------------------
 
+  // used while Props drilling but later moved to CartContext.tsx 
   //  Global Cart state (array of {product, quantity})
-  const [cartItems, setCartItems] = useState<{ product: Product, quantity: number }[]>([])
-
-  //  addToCart logic
-  const addToCart = (product: Product) => {
-    setCartItems((prevItems) => updateCartItems(prevItems , product))
-  }
+  // const [cartItems, setCartItems] = useState<{ product: Product, quantity: number }[]>([])
 
   return (
+    //CartProvider wraps the entire app to provide cart state globally
     <Router>
+    <CartProvider>
       <Header />
       <main className='p-4'>
         <Routes>
           {/* Pass products and addToCart to Home */}
           <Route
-            path="/" element={<Home 
-              // products={products}  --> static rendering  
-              addToCart={addToCart} />}
-          // path='/'
-          // element={<Home />}
+            path="/" 
+            element={<Home />}
           />
 
           <Route
@@ -59,9 +55,10 @@ const App: React.FC = () => {
 
           <Route
             path='/cart'
-            element={<Cart cartItems={cartItems}  setCartItems={setCartItems}/>} />
+            element={<Cart />} />
         </Routes>
       </main>
+    </CartProvider>
     </Router>
   )
 }

--- a/fakecart/src/components/cart/CartDynamic.tsx
+++ b/fakecart/src/components/cart/CartDynamic.tsx
@@ -1,6 +1,7 @@
 // Import React and useState hook from React
-import React, { useState } from 'react';
-import type { Product } from '../../types';
+// import React, { useState } from 'react';
+// import type { CartItem, Product } from '../../types';
+import { useCart } from '../../context/CartContext';
 
 // -----------Static
 //  Define the structure (TypeScript type) for a cart item
@@ -11,20 +12,19 @@ import type { Product } from '../../types';
 //     quantity: number;   // Quantity of this item in the cart
 // };
 
-type CartDynamicProps = {
-    cartItems: { product: Product; quantity: number }[];
-    setCartItems: React.Dispatch<React.SetStateAction<{ 
-    product: Product; 
-    quantity: number 
-    }[]>>;
-};
+// type CartDynamicProps = {
+//     cartItems: CartItem[];
+//     setCartItems: React.Dispatch<React.SetStateAction<CartItem[]>>;
+// };
 
 
 //Define the CartDynamic component (our dynamic cart logic lives here)
-const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
+const CartDynamic = () => {
+
+    const {cartItems, setCartItems} = useCart();
     //Calculate the total cost using reduce
     const total = cartItems.reduce(
-        (sum, item) => sum + item.product.price * item.quantity,
+        (sum, item) => sum + item.price * item.quantity,
         0
     );
 
@@ -40,7 +40,7 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
 
     const handleIncrement = (id: number) => {
         setCartItems(prevItems =>
-        (prevItems.map(item => item.product.id === id
+        (prevItems.map(item => item.id === id
             ? { ...item, quantity: Math.min(item.quantity + 1, 10) } : item
         )
         ));
@@ -57,7 +57,7 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
     // }
 
     const handleDecrement = (id: number) => {
-        const item = cartItems.find(item => item.product.id === id)
+        const item = cartItems.find(item => item.id === id)
 
         if (!item) return;
 
@@ -68,7 +68,7 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
                 return;
         }
         setCartItems(prevItems => prevItems.map(
-            item => item.product.id === id ? { ...item, quantity: item.quantity - 1 } : item
+            item => item.id === id ? { ...item, quantity: item.quantity - 1 } : item
         ).filter(item => item.quantity > 0))
     }
 
@@ -80,7 +80,7 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
         // If the user clicks Cancel, stop right here. Don’t continue.
         if (!confirmDelete) return;
 
-        setCartItems(prevItems => prevItems.filter(item => item.product.id !== id));
+        setCartItems(prevItems => prevItems.filter(item => item.id !== id));
     };
 
 
@@ -98,30 +98,30 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
                         {cartItems.map((item) => (
                             // we can also destructure item into {cartItems.map(({ product, quantity }) 
                             <li
-                                key={item.product.id}
+                                key={item.id}
                                 className="flex justify-between border-b pb-2 text-gray-700"
                             >
                                 <div>
-                                    <p className="font-medium">{item.product.name}</p>
+                                    <p className="font-medium">{item.name}</p>
                                     <p className="text-sm text-gray-500">
-                                        ₹{item.product.price} × {item.quantity}
+                                        ₹{item.price} × {item.quantity}
                                     </p>
                                 </div>
                                 <span className="font-semibold">
-                                    ₹{item.product.price * item.quantity}
+                                    ₹{item.price * item.quantity}
                                 </span>
 
                                 {/*Quantity controls */}
                                 <div className="flex items-center space-x-2">
                                     <button
-                                        onClick={() => handleDecrement(item.product.id)}
+                                        onClick={() => handleDecrement(item.id)}
                                         className="px-2 bg-gray-200 rounded hover:bg-gray-300"
                                     >
                                         -
                                     </button>
                                     <span>{item.quantity}</span>
                                     <button
-                                        onClick={() => handleIncrement(item.product.id)}
+                                        onClick={() => handleIncrement(item.id)}
                                         className="px-2 bg-gray-200 rounded hover:bg-gray-300"
                                     >
                                         +
@@ -129,7 +129,7 @@ const CartDynamic = ({ cartItems, setCartItems }: CartDynamicProps) => {
 
                                     {/* ✅ Delete button */}
                                     <button
-                                        onClick={() => handleDelete(item.product.id)}
+                                        onClick={() => handleDelete(item.id)}
                                         className="text-red-500 hover:underline text-sm ml-4"
                                     >
                                         Remove

--- a/fakecart/src/components/home/HomeDynamic.tsx
+++ b/fakecart/src/components/home/HomeDynamic.tsx
@@ -1,16 +1,19 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import ProductList from '../product/ProductList'
-import type { Product, HomeProps } from '../../types';
+import type { Product } from '../../types';
+import { useCart } from '../../context/CartContext';
 
 // type HomeDynamicProps = {
 //     addToCart: (product: Product) => void
 // }
 
 
-const HomeDynamic = ({ addToCart }: HomeProps) => {
+const HomeDynamic = () => {
 
-
+    // Use addToCart from context
+    const {addToCart} = useCart() ; 
+    
     // State to hold products fetched from API
     const [products, setProducts] = useState<Product[]>([])
 

--- a/fakecart/src/components/home/HomeStatic.tsx
+++ b/fakecart/src/components/home/HomeStatic.tsx
@@ -1,10 +1,12 @@
-import React from 'react'
-import type { Product } from '../../types/Product'
+// import React from 'react'
+// import type { Product } from '../../types/Product'
 import ProductList from '../product/ProductList';
 import type { HomeProps } from '../../types';
+import { useCart } from '../../context/CartContext';
 
 
-const HomeStatic = ({ products = [], addToCart }: HomeProps) => {
+const HomeStatic = ({ products = [] }: HomeProps) => {
+  const { addToCart } = useCart()
   return (
     <>
     <h1 className='text-2xl font-bold mb-4'>Welcome to FakeCart</h1>

--- a/fakecart/src/components/product/ProductCard.tsx
+++ b/fakecart/src/components/product/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+// import React from 'react'
 // import type { Product } from '../../types/Product';
 import type { Product } from '../../types';
 

--- a/fakecart/src/components/product/ProductList.tsx
+++ b/fakecart/src/components/product/ProductList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+// import React from 'react'
 import ProductCard from './ProductCard';
 // import type { Product } from '../../types/Product';
 import type { Product } from '../../types';

--- a/fakecart/src/context/CartContext.tsx
+++ b/fakecart/src/context/CartContext.tsx
@@ -1,0 +1,42 @@
+import { Children, createContext, useContext, useState } from "react";
+import type { CartItem, Product } from "../types";
+import { updateCartItems } from "../utils/cartUtils";
+
+// 1. Define the shape of our context
+interface CartContextType {
+    cartItems: CartItem[];
+    addToCart: (product: Product) => void;
+    setCartItems: React.Dispatch<React.SetStateAction<CartItem[]>>;
+}
+
+// 2. Create the actual context with an initial undefined value
+const CartContext = createContext<CartContextType | undefined>(undefined);
+// 3. CartProvider wraps the app and gives children access to cart state.
+export const CartProvider = ({ children }: { children: React.ReactNode }) => {
+    const [cartItems, setCartItems] = useState<CartItem[]>([]);
+
+    const addToCart = (product: Product) => {
+        const updatedItems = updateCartItems(cartItems, product)
+        setCartItems(updatedItems);
+    }
+    return (
+        <CartContext.Provider value={{ cartItems, addToCart,setCartItems }}>
+            {children}
+        </CartContext.Provider>
+    );
+
+};
+
+
+// 4. Custom hook to safely access the CartContext.
+// This makes consuming code cleaner and avoids repeating useContext everywhere.
+
+export const useCart = (): CartContextType => {
+    const context = useContext(CartContext);
+
+    if (!context){
+        throw new Error('useCart must be used within a cart provider');
+    }
+    return context;
+
+}

--- a/fakecart/src/main.tsx
+++ b/fakecart/src/main.tsx
@@ -2,9 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { CartProvider } from './context/CartContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <CartProvider> 
+      <App />
+    </CartProvider>
   </StrictMode>,
 )
+
+// wrapping , else  no component can access the CartContext — this connects it.

--- a/fakecart/src/pages/Cart.tsx
+++ b/fakecart/src/pages/Cart.tsx
@@ -1,23 +1,32 @@
-import React from 'react'
 // import CartStatic from '../components/cart/CartStatic'
 import CartDynamic from '../components/cart/CartDynamic'
-import type { Product } from '../types';
+// import type { Product } from '../types';
 
 
-type CartPageProps = {
-  cartItems: { product: Product; quantity: number }[];
-  setCartItems: React.Dispatch<React.SetStateAction<{ product: Product; quantity: number }[]>>;
-};
+// type CartPageProps = {
+//   cartItems: { product: Product; quantity: number }[];
+//   setCartItems: React.Dispatch<React.SetStateAction<{ product: Product; quantity: number }[]>>;
+// };
+
+// required while props ddrilling
+// const Cart = ({ cartItems, setCartItems }: CartPageProps) => {
+//   return (
+//     <>
+//       {/* <div><CartStatic/></div> */}
+//       <div><CartDynamic cartItems={cartItems} setCartItems={setCartItems} /></div>
+//     </>
+
+//   )
+// }
+
+//----------------- uses context API
+
+const Cart = () => {
+  // Destructure cartItems from CartContext
 
 
-const Cart = ({ cartItems, setCartItems }: CartPageProps) => {
-  return (
-    <>
-      {/* <div><CartStatic/></div> */}
-      <div><CartDynamic cartItems={cartItems} setCartItems={setCartItems} /></div>
-    </>
-
-  )
+  // Pass it down to UI component (no props needed from App.tsx)
+  return <CartDynamic />
 }
 
 export default Cart

--- a/fakecart/src/pages/Home.tsx
+++ b/fakecart/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 // import HomeStatic from '../components/home/HomeStatic'
 // import type { Product } from '../types/Product';
 // import type { HomeProps } from '../types/HomeProps';
-import type { HomeProps } from '../types';
 import HomeDynamic from '../components/home/HomeDynamic';
 
             // used for HomeStatic
@@ -16,8 +15,8 @@ import HomeDynamic from '../components/home/HomeDynamic';
 //   return <HomeStatic products={products} addToCart={addToCart} />;
 // };
 // --------------------------------------------------------------
-const Home = ({ addToCart }: HomeProps) => {
-  return <HomeDynamic addToCart={addToCart} />
+const Home = () => {
+  return <HomeDynamic/>
 }
 
 export default Home

--- a/fakecart/src/types/CartTypes.ts
+++ b/fakecart/src/types/CartTypes.ts
@@ -1,0 +1,10 @@
+// 
+//  - A CartItem extends Product by adding quantity.
+//  - This allows us to track how many of each product is added to the cart.
+//  
+
+import type { Product } from "./Product";
+
+export interface CartItem extends Product {
+  quantity: number;
+}

--- a/fakecart/src/types/HomeProps.ts
+++ b/fakecart/src/types/HomeProps.ts
@@ -3,5 +3,9 @@ import type { Product } from "./Product";
 
 export interface HomeProps {
   products?: Product[]; // Optional for HomeDynamic
-  addToCart: (product: Product) => void;
+  // addToCart() becomes reduntant once we use CartContext as this is 
+  // Now consumed from CartContext using useCart()
+  // addToCart: (product: Product) => void;
 }
+
+// We remove props like addToCart and consume them directly from context using a custom hook like useCart(), which improves modularity and reduces prop bloat."

--- a/fakecart/src/types/index.ts
+++ b/fakecart/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Product';
 export * from './HomeProps';
+export * from './CartTypes';

--- a/fakecart/src/utils/cartUtils.ts
+++ b/fakecart/src/utils/cartUtils.ts
@@ -1,22 +1,31 @@
-import type { Product } from "../types/Product";
+  import type { CartItem } from "../types";
+  import type { Product } from "../types/Product";
 
-export const updateCartItems = (
-  cartItems: { product: Product; quantity: number }[], // the current cart
-  product: Product // the product the user just added
-): { product: Product; quantity: number }[] => { 
-    // return: updated cart array
+  export const updateCartItems = (
+    cartItems: CartItem[], // the current cart
+    product: Product // the product the user just added
+  ): CartItem[] => { 
+      // return: updated cart array
 
-  // Look for an existing item in the cart with the same product ID
-  const existing = cartItems.find(item => item.product.id === product.id);
+    // Look for an existing item in the cart with the same product ID
+    const existing = cartItems.find(item => item.id === product.id);
 
-  // If found, update quantity (max 10), otherwise add new item
-  if (existing) {
-    return cartItems.map(item =>
-      item.product.id === product.id
-        ? { ...item, quantity: Math.min(item.quantity + 1, 10) } // increase quantity
-        : item
-    );
-  } else {
-    return [...cartItems, { product, quantity: 1 }]; // add new product with quantity 1
-  }
-};
+    // If found, update quantity (max 10), otherwise add new item
+    if (existing) {
+      return cartItems.map(item =>
+        item.id === product.id
+          ? { ...item, quantity: Math.min(item.quantity + 1, 10) } // increase quantity
+          : item
+      );
+    } else {
+      return [...cartItems, { ...product, quantity: 1 }]; // add new product with quantity 1
+    }
+  };
+
+
+  // ---------------------------------------------------
+// CartItem extends Product, so { ...product, quantity: 1 } is valid.
+
+// array is now of type CartItem[], not { product, quantity }[].
+
+// This aligns with the context and all usages expecting CartItem[].


### PR DESCRIPTION
## Changelog

- Created `CartContext` to manage global cart state
- Updated `App.tsx` to wrap the app in `CartProvider`
- Removed prop drilling of `cartItems` and `addToCart`
- `ProductList` now consumes `useCart` directly
- `Cart` page and components now consume cart via context
- Added `types/CartTypes.
